### PR TITLE
Add a cache mechanism to gulp

### DIFF
--- a/gulp-task-runner.el
+++ b/gulp-task-runner.el
@@ -26,18 +26,63 @@
 
 ;;; Code:
 
+(defvar gulp--task-cache nil
+  "Map gulpfile path to the list of its tasks.")
+
 ;;;###autoload
-(defun gulp ()
-  "Prompt for a gulp task and run it."
-  (interactive)
+(defun gulp (&optional prefix)
+  "Prompt for a gulp task and run it.
+With PREFIX or when called interactively with a prefix argument,
+forces reload of the task list from gulpfile.js."
+  (interactive "P")
+  (when prefix
+    (gulp--invalidate-cache))
   (let* ((tasks (gulp--get-tasks))
          (task (completing-read "Gulp task: " tasks)))
     (let ((compilation-buffer-name-function #'gulp--get-buffer-name))
-     (compilation-start (format "gulp %s" task)))))
+      (compilation-start (format "gulp %s" task)))))
+
+(defun gulp--add-to-cache (gulpfile tasks)
+  "Add (GULPFILE TASKS) to `gulp--task-cache'."
+  ;; because we are using alist functions, there is no need to erase
+  ;; pairs with same key
+  (setq gulp--task-cache
+        (cons (cons gulpfile tasks)
+              gulp--task-cache)))
+
+(defun gulp--invalidate-cache (&optional gulpfile)
+  "Remove cached task list for GULPFILE.
+If GULPFILE is nil, remove task list for `gulp--get-gulpfile'."
+  (let ((gulpfile (or gulpfile (gulp--get-gulpfile))))
+    (gulp--add-to-cache gulpfile nil)))
+
+(defun gulp--get-gulpfile (&optional dir)
+  "Return path of the gulpfile from DIR or `default-directory'."
+  (let ((dir (or dir default-directory)))
+    (expand-file-name
+     "gulpfile.js"
+     (locate-dominating-file (or dir default-directory)
+                             "gulpfile.js"))))
+
+(defun gulp--get-tasks-from-gulp ()
+  "Ask gulp for a task list."
+  (process-lines "gulp" "--tasks-simple"))
+
+(defun gulp--get-tasks-from-cache (&optional gulpfile)
+  "Lookup for a task list for GULPFILE in `gulp--task-cache'.
+If GULPFILE is absent, its value is takend from
+`gulp--get-gulpfile'."
+  (let ((gulpfile (or gulpfile (gulp--get-gulpfile))))
+    (cdr (assoc gulpfile gulp--task-cache))))
 
 (defun gulp--get-tasks ()
   "Return a list of gulp tasks for the current project."
-  (process-lines "gulp" "--tasks-simple"))
+  (let* ((gulpfile (gulp--get-gulpfile)))
+    (or (gulp--get-tasks-from-cache gulpfile)
+        (let ((tasks (gulp--get-tasks-from-gulp)))
+          (setq gulp--task-cache (cons (cons gulpfile tasks)
+                                       gulp--task-cache))
+          tasks))))
 
 (defun gulp--get-buffer-name (&rest _)
   "Return the name of a gulp task buffer."


### PR DESCRIPTION
Running `gulp --tasks-simple` is a bit slow (around 0.75s on my
computer). This patch caches the command's result so the command doesn't
have to be executed each time the user wants the task list. To
invalidate the cache, the user must pass a prefix argument to
`gulp` (i.e., `C-u M-x gulp`).
